### PR TITLE
Throw exceptions that include the HTTP status code and response

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -202,6 +202,8 @@
                 <configuration>
                     <failOnError>true</failOnError>
                     <verbose>true</verbose>
+                    <source>1.6</source>
+                    <target>1.6</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/org/yamj/api/common/exception/ClientAPIException.java
+++ b/src/main/java/org/yamj/api/common/exception/ClientAPIException.java
@@ -1,0 +1,30 @@
+package org.yamj.api.common.exception;
+
+import javax.xml.ws.WebServiceException;
+
+import org.yamj.api.common.http.DigestedResponse;
+
+public class ClientAPIException extends WebServiceException {
+
+    private static final long serialVersionUID = 278660717634380289L;
+
+    private final DigestedResponse response;
+
+    public ClientAPIException(final DigestedResponse response) {
+
+        super();
+        this.response = response;
+    }
+
+    public ClientAPIException(final DigestedResponse response,
+                              final Throwable cause) {
+
+        super(cause);
+        this.response = response;
+    }
+
+    public DigestedResponse getResponse() {
+
+        return response;
+    }
+}

--- a/src/main/java/org/yamj/api/common/http/AbstractPoolingHttpClient.java
+++ b/src/main/java/org/yamj/api/common/http/AbstractPoolingHttpClient.java
@@ -25,6 +25,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.StringWriter;
 import java.nio.charset.Charset;
+
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.Consts;
 import org.apache.http.HttpHost;
@@ -197,11 +198,14 @@ public abstract class AbstractPoolingHttpClient extends AbstractHttpClient imple
         return clientManager;
     }
 
-    protected String readContent(HttpResponse response, Charset charset) throws IOException {
+    protected DigestedResponse readContent(final HttpResponse response, final Charset charset) throws IOException {
         StringWriter content = new StringWriter(SW_BUFFER_10K);
         InputStream is = response.getEntity().getContent();
         InputStreamReader isr = null;
         BufferedReader br = null;
+
+        final DigestedResponse digestedResponse = new DigestedResponse();
+        digestedResponse.setStatusCode(response.getStatusLine().getStatusCode());
 
         try {
             if (charset == null) {
@@ -218,7 +222,8 @@ public abstract class AbstractPoolingHttpClient extends AbstractHttpClient imple
             }
 
             content.flush();
-            return content.toString();
+            digestedResponse.setContent(content.toString());
+            return digestedResponse;
         } finally {
             if (br != null) {
                 try {

--- a/src/main/java/org/yamj/api/common/http/CommonHttpClient.java
+++ b/src/main/java/org/yamj/api/common/http/CommonHttpClient.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
 import java.nio.charset.Charset;
+
 import org.apache.http.HttpEntity;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
@@ -33,21 +34,21 @@ public interface CommonHttpClient extends HttpClient {
 
     void setTimeouts(int connectionTimeout, int socketTimeout);
 
-    String requestContent(URL url) throws IOException;
+    DigestedResponse requestContent(URL url) throws IOException;
 
-    String requestContent(URL url, Charset charset) throws IOException;
+    DigestedResponse requestContent(URL url, Charset charset) throws IOException;
 
-    String requestContent(String uri) throws IOException;
+    DigestedResponse requestContent(String uri) throws IOException;
 
-    String requestContent(String uri, Charset charset) throws IOException;
+    DigestedResponse requestContent(String uri, Charset charset) throws IOException;
 
-    String requestContent(URI uri) throws IOException;
+    DigestedResponse requestContent(URI uri) throws IOException;
 
-    String requestContent(URI uri, Charset charset) throws IOException;
+    DigestedResponse requestContent(URI uri, Charset charset) throws IOException;
 
-    String requestContent(HttpGet httpGet) throws IOException;
+    DigestedResponse requestContent(HttpGet httpGet) throws IOException;
 
-    String requestContent(HttpGet httpGet, Charset charset) throws IOException;
+    DigestedResponse requestContent(HttpGet httpGet, Charset charset) throws IOException;
 
     HttpEntity requestResource(URL url) throws IOException;
 

--- a/src/main/java/org/yamj/api/common/http/DefaultPoolingHttpClient.java
+++ b/src/main/java/org/yamj/api/common/http/DefaultPoolingHttpClient.java
@@ -24,6 +24,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.charset.Charset;
+
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -57,12 +58,12 @@ public class DefaultPoolingHttpClient extends AbstractPoolingHttpClient {
     }
 
     @Override
-    public String requestContent(URL url) throws IOException {
+    public DigestedResponse requestContent(URL url) throws IOException {
         return requestContent(url, null);
     }
 
     @Override
-    public String requestContent(URL url, Charset charset) throws IOException {
+    public DigestedResponse requestContent(URL url, Charset charset) throws IOException {
         URI uri;
         try {
             uri = url.toURI();
@@ -74,46 +75,48 @@ public class DefaultPoolingHttpClient extends AbstractPoolingHttpClient {
     }
 
     @Override
-    public String requestContent(String uri) throws IOException {
+    public DigestedResponse requestContent(String uri) throws IOException {
         return requestContent(uri, null);
     }
 
     @Override
-    public String requestContent(String uri, Charset charset) throws IOException {
+    public DigestedResponse requestContent(String uri, Charset charset) throws IOException {
         HttpGet httpGet = new HttpGet(uri);
         return requestContent(httpGet, charset);
     }
 
     @Override
-    public String requestContent(URI uri) throws IOException {
+    public DigestedResponse requestContent(URI uri) throws IOException {
         return requestContent(uri, null);
     }
 
     @Override
-    public String requestContent(URI uri, Charset charset) throws IOException {
+    public DigestedResponse requestContent(URI uri, Charset charset) throws IOException {
         HttpGet httpGet = new HttpGet(uri);
         return requestContent(httpGet, charset);
     }
 
     @Override
-    public String requestContent(HttpGet httpGet) throws IOException {
+    public DigestedResponse requestContent(HttpGet httpGet) throws IOException {
         return requestContent(httpGet, null);
     }
 
     @Override
-    public String requestContent(HttpGet httpGet, Charset charset) throws IOException {
+    public DigestedResponse requestContent(HttpGet httpGet, Charset charset) throws IOException {
         if (randomUserAgent) {
             httpGet.setHeader(HTTP.USER_AGENT, UserAgentSelector.randomUserAgent());
         }
 
         try {
-            HttpResponse response = execute(httpGet);
+
+            final HttpResponse response = execute(httpGet);
             if (response.getEntity() == null) {
                 httpGet.releaseConnection();
                 throw new IOException("No response for URI " + httpGet.getURI());
-            } else {
-                return readContent(response, charset);
             }
+
+            return readContent(response, charset);
+
         } catch (IOException ioe) {
             httpGet.releaseConnection();
             throw ioe;

--- a/src/main/java/org/yamj/api/common/http/DigestedResponse.java
+++ b/src/main/java/org/yamj/api/common/http/DigestedResponse.java
@@ -1,0 +1,50 @@
+package org.yamj.api.common.http;
+
+/**
+ * Contains the content of the digested response stream body and its HTTP status code.
+ */
+public class DigestedResponse {
+
+    private int statusCode;
+
+    private String content;
+
+    public DigestedResponse() {
+
+        super();
+    }
+
+    public DigestedResponse(final int statusCode,
+                            final String content) {
+
+        super();
+        this.statusCode = statusCode;
+        this.content = content;
+    }
+
+    public int getStatusCode() {
+
+        return statusCode;
+    }
+
+    public void setStatusCode(final int statusCode) {
+
+        this.statusCode = statusCode;
+    }
+
+    public String getContent() {
+
+        return content;
+    }
+
+    public void setContent(final String content) {
+
+        this.content = content;
+    }
+
+    @Override
+    public String toString() {
+
+        return new StringBuilder().append(this.statusCode).append(" ").append(this.content).toString();
+    }
+}


### PR DESCRIPTION
So here’s my change for Omertron/api-thetvdb#3
The response string is now wrapped inside `DigestedResponse`, which also includes the HTTP status code. API-TheTVDB (and others) may now use the response’s status code to maybe throw an exception like `ClientAPIException`.
